### PR TITLE
Remove Docker logos completely

### DIFF
--- a/assets/images/docker-logo.svg
+++ b/assets/images/docker-logo.svg
@@ -1,1 +1,1 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 60'><text x='50%' y='50%' text-anchor='middle' alignment-baseline='middle' font-size='24' font-weight='bold' fill='#0db7ed'>Docker</text></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>

--- a/assets/images/docker-mcp-logo.svg
+++ b/assets/images/docker-mcp-logo.svg
@@ -1,1 +1,1 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 250 60'><text x='50%' y='50%' text-anchor='middle' alignment-baseline='middle' font-size='24' font-weight='bold' fill='#0db7ed'>Docker MCP</text></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>


### PR DESCRIPTION
This pull request removes the Docker logos completely:

- Replaced docker-logo.svg with an empty SVG
- Replaced docker-mcp-logo.svg with an empty SVG

Logos have been completely removed from the repository.