### PR TITLE
Update logos with MCP Community Portal text

### DIFF
--- a/assets/images/docker-logo.svg
+++ b/assets/images/docker-logo.svg
@@ -1,1 +1,1 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 60'><text x='50%' y='50%' text-anchor='middle' alignment-baseline='middle' font-size='24' font-weight='bold' fill='#333'>MCP Community Portal</text></svg>

--- a/assets/images/docker-mcp-logo.svg
+++ b/assets/images/docker-mcp-logo.svg
@@ -1,1 +1,1 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 60'><text x='50%' y='50%' text-anchor='middle' alignment-baseline='middle' font-size='24' font-weight='bold' fill='#333'>MCP Community Portal</text></svg>


### PR DESCRIPTION
This pull request updates the Docker logos with "MCP Community Portal" text:

- Replaced docker-logo.svg with text "MCP Community Portal"
- Replaced docker-mcp-logo.svg with text "MCP Community Portal"
- Used a neutral dark gray color (#333)
- Centered and bolded text

Addresses any previous conflicts and removes Docker branding while maintaining a clear logo.